### PR TITLE
Fix #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ def my_task(**task_input):
 
 if __name__ == "__main__":
     activity_arn = "PLACE YOUR ACTIVITY ARN HERE"
-    worker = ActiityWorker(activity_arn, my_task)
+    worker = ActivityWorker(activity_arn, my_task)
     worker.listen()
 ```
 

--- a/stepfunctions_activity_worker/activity_worker.py
+++ b/stepfunctions_activity_worker/activity_worker.py
@@ -47,6 +47,7 @@ class ActivityWorker:
         return boto3.client('stepfunctions', config=config)
 
     def __call__(self):
+        """Perform task execution."""
         self.perform_task()
 
     def _poll_for_task(self):

--- a/stepfunctions_activity_worker/activity_worker.py
+++ b/stepfunctions_activity_worker/activity_worker.py
@@ -8,6 +8,7 @@ import traceback
 
 import boto3
 import botocore.config
+from botocore.exceptions import ClientError
 
 from .heartbeat import Heartbeat
 
@@ -83,16 +84,22 @@ class ActivityWorker:
                 error=str(error)[:256],
                 cause="\n".join(formatted_traceback),
             )
-            self._task_semaphore.release()
             raise
+        finally:
+            self._task_semaphore.release()
 
-        print(f"{self.activity_name} is completed!")
-        print(json.dumps(output, indent=4, sort_keys=True))
-        self.stepfunctions.send_task_success(
-            taskToken=task["taskToken"],
-            output=json.dumps(output, sort_keys=True),
-        )
-        self._task_semaphore.release()
+        try:
+            self.stepfunctions.send_task_success(
+                taskToken=task["taskToken"],
+                output=json.dumps(output, sort_keys=True),
+            )
+            print(f"{self.activity_name} is completed!")
+            print(json.dumps(output, indent=4, sort_keys=True))
+        except ClientError as exception:
+            print("Execution completed but could not send task success.")
+            print(exception)
+        finally:
+            self._task_semaphore.release()
 
     def listen(self):
         """Repeatedly listen & execute tasks associated with this activity."""


### PR DESCRIPTION
Fixes #11 

Ideally the task should stop performing work when/if there's a timeout.
However, since the heartbeat is running off in it's own thread, propagating that to the blocking action that is running work is a larger challenge.

For the time being, making sure the semaphore releases even if `send_task_success` fails should be sufficient.